### PR TITLE
[BE] fix: jwt가 null일 때 처리 및 아이디 닉네임 중복 체크 결과값 수정#16

### DIFF
--- a/BE/src/main/java/com/hymin/webtoon_review/global/security/provider/JwtAuthenticationProvider.java
+++ b/BE/src/main/java/com/hymin/webtoon_review/global/security/provider/JwtAuthenticationProvider.java
@@ -22,9 +22,8 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication)
         throws AuthenticationException {
-        String jwt = authentication.getCredentials().toString();
-
         try {
+            String jwt = authentication.getCredentials().toString();
             Claims claims = jwtService.parseJwt(jwt);
 
             String username = claims.getSubject();
@@ -36,7 +35,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
             return new JwtAuthentication(username, "", authorities);
         } catch (ExpiredJwtException e) {
             throw new BadCredentialsException("만료된 토큰입니다.", e);
-        } catch (JwtException e) {
+        } catch (JwtException | NullPointerException e) {
             throw new BadCredentialsException("유효하지 않는 토큰입니다.", e);
         }
     }

--- a/BE/src/main/java/com/hymin/webtoon_review/user/service/UserService.java
+++ b/BE/src/main/java/com/hymin/webtoon_review/user/service/UserService.java
@@ -45,18 +45,18 @@ public class UserService {
         if (!authentication.isAuthenticated()) {
             throw new UserNotFoundException(ResponseStatus.LOGIN_FAILED);
         }
-        
+
         String jwt = jwtService.createJwt(authentication);
 
         return "Bearer " + jwt;
     }
 
     public Boolean checkDuplicatedUsername(String username) {
-        return !userRepository.existsByUsername(username);
+        return userRepository.existsByUsername(username);
     }
 
     public Boolean checkDuplicatedNickname(String nickname) {
-        return !userRepository.existsByNickname(nickname);
+        return userRepository.existsByNickname(nickname);
     }
 
     private Authority createUserAuthority(User user) {

--- a/BE/src/test/java/com/hymin/webtoon_review/user/controller/UserControllerTest.java
+++ b/BE/src/test/java/com/hymin/webtoon_review/user/controller/UserControllerTest.java
@@ -44,14 +44,14 @@ class UserControllerTest {
 
         // when
         when(userService.checkDuplicatedUsername(username))
-            .thenReturn(true);
+            .thenReturn(false);
 
         // then
         mockMvc.perform(get("/users/check/username")
                 .queryParam("username", username))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data").value(true));
+            .andExpect(jsonPath("$.data").value(false));
     }
 
     @Test
@@ -62,19 +62,37 @@ class UserControllerTest {
 
         // when
         when(userService.checkDuplicatedUsername(username))
-            .thenReturn(false);
+            .thenReturn(true);
 
         // then
         mockMvc.perform(get("/users/check/username")
                 .queryParam("username", username))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data").value(false));
+            .andExpect(jsonPath("$.data").value(true));
     }
 
     @Test
     @DisplayName("사용 가능한 nickname")
     public void availableNickname() throws Exception {
+        // given
+        String nickname = "nickname";
+
+        // when
+        when(userService.checkDuplicatedNickname(nickname))
+            .thenReturn(false);
+
+        // then
+        mockMvc.perform(get("/users/check/nickname")
+                .queryParam("nickname", nickname))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data").value(false));
+    }
+
+    @Test
+    @DisplayName("사용 불가능한 nickname")
+    public void notAvailableNickname() throws Exception {
         // given
         String nickname = "nickname";
 
@@ -88,24 +106,6 @@ class UserControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(200))
             .andExpect(jsonPath("$.data").value(true));
-    }
-
-    @Test
-    @DisplayName("사용 불가능한 nickname")
-    public void notAvailableNickname() throws Exception {
-        // given
-        String nickname = "nickname";
-
-        // when
-        when(userService.checkDuplicatedNickname(nickname))
-            .thenReturn(false);
-
-        // then
-        mockMvc.perform(get("/users/check/nickname")
-                .queryParam("nickname", nickname))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data").value(false));
     }
 
     @Test

--- a/BE/src/test/java/com/hymin/webtoon_review/user/service/UserServiceTest.java
+++ b/BE/src/test/java/com/hymin/webtoon_review/user/service/UserServiceTest.java
@@ -78,7 +78,7 @@ class UserServiceTest {
         // then
         Boolean b = userService.checkDuplicatedNickname(nickname);
 
-        assertEquals(b, true);
+        assertEquals(b, false);
     }
 
     @Test
@@ -93,7 +93,7 @@ class UserServiceTest {
         // then
         Boolean b = userService.checkDuplicatedNickname(nickname);
 
-        assertEquals(b, false);
+        assertEquals(b, true);
     }
 
     @Test


### PR DESCRIPTION
## 💻 작업 내용

- jwt가 null일 때 처리
- 아이디, 닉네임 결과 값 수정
- 아이디, 닉네임 중복 확인 테스트 수정